### PR TITLE
Updated dependencies and upgraded xunit version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,19 +7,19 @@
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.15.1" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.16.0" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.19.0.132793" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.20.0.135146" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.1.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.1.1" />
-    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.1.1-preview.1.26105.8" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.1" />
-    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.1.1-preview.1.26105.8" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.1" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.1.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.1.2-preview.1.26125.13" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="13.1.2-preview.1.26125.13" />
+    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.2" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.1.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="Dapper" Version="2.1.66" />
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="MudBlazor" Version="9.0.0" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
@@ -40,9 +40,9 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.46" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.52" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/src/Backend/Modules/Attendance/test/SilverbridgeWeb.Modules.Attendance.ArchitectureTests/Abstractions/TestResultExtensions.cs
+++ b/src/Backend/Modules/Attendance/test/SilverbridgeWeb.Modules.Attendance.ArchitectureTests/Abstractions/TestResultExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using FluentAssertions;
-using NetArchTest.Rules;
 
 namespace SilverbridgeWeb.Modules.Attendance.ArchitectureTests.Abstractions;
 
 internal static class TestResultExtensions
 {
-    internal static void ShouldBeSuccessful(this TestResult testResult)
+    internal static void ShouldBeSuccessful(this NetArchTest.Rules.TestResult testResult)
     {
         testResult.FailingTypes?.Should().BeEmpty();
     }

--- a/src/Backend/Modules/Attendance/test/SilverbridgeWeb.Modules.Attendance.ArchitectureTests/SilverbridgeWeb.Modules.Attendance.ArchitectureTests.csproj
+++ b/src/Backend/Modules/Attendance/test/SilverbridgeWeb.Modules.Attendance.ArchitectureTests/SilverbridgeWeb.Modules.Attendance.ArchitectureTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<OutputType>Exe</OutputType>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
@@ -13,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NetArchTest.Rules" />
-		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.v3" />
 		<PackageReference Include="xunit.runner.visualstudio" />
 	</ItemGroup>
 

--- a/src/Backend/Modules/Events/test/SilverbridgeWeb.Modules.Events.ArchitectureTests/Abstractions/TestResultExtensions.cs
+++ b/src/Backend/Modules/Events/test/SilverbridgeWeb.Modules.Events.ArchitectureTests/Abstractions/TestResultExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using FluentAssertions;
-using NetArchTest.Rules;
 
 namespace SilverbridgeWeb.Modules.Events.ArchitectureTests.Abstractions;
 
 internal static class TestResultExtensions
 {
-    internal static void ShouldBeSuccessful(this TestResult testResult)
+    internal static void ShouldBeSuccessful(this NetArchTest.Rules.TestResult testResult)
     {
         testResult.FailingTypes?.Should().BeEmpty();
     }

--- a/src/Backend/Modules/Events/test/SilverbridgeWeb.Modules.Events.ArchitectureTests/SilverbridgeWeb.Modules.Events.ArchitectureTests.csproj
+++ b/src/Backend/Modules/Events/test/SilverbridgeWeb.Modules.Events.ArchitectureTests/SilverbridgeWeb.Modules.Events.ArchitectureTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -13,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NetArchTest.Rules" />
-		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.v3" />
 		<PackageReference Include="xunit.runner.visualstudio" />
 	</ItemGroup>
 

--- a/src/Backend/Modules/Ticketing/test/SilverbridgeWeb.Modules.Ticketing.ArchitectureTests/Abstractions/TestResultExtensions.cs
+++ b/src/Backend/Modules/Ticketing/test/SilverbridgeWeb.Modules.Ticketing.ArchitectureTests/Abstractions/TestResultExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using FluentAssertions;
-using NetArchTest.Rules;
 
 namespace SilverbridgeWeb.Modules.Ticketing.ArchitectureTests.Abstractions;
 
 internal static class TestResultExtensions
 {
-    internal static void ShouldBeSuccessful(this TestResult testResult)
+    internal static void ShouldBeSuccessful(this NetArchTest.Rules.TestResult testResult)
     {
         testResult.FailingTypes?.Should().BeEmpty();
     }

--- a/src/Backend/Modules/Ticketing/test/SilverbridgeWeb.Modules.Ticketing.ArchitectureTests/SilverbridgeWeb.Modules.Ticketing.ArchitectureTests.csproj
+++ b/src/Backend/Modules/Ticketing/test/SilverbridgeWeb.Modules.Ticketing.ArchitectureTests/SilverbridgeWeb.Modules.Ticketing.ArchitectureTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -13,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="NetArchTest.Rules" />
-		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.v3" />
 		<PackageReference Include="xunit.runner.visualstudio" />
 	</ItemGroup>
 

--- a/src/Backend/Modules/Users/test/SilverbridgeWeb.Modules.Users.ArchitectureTests/Abstractions/TestResultExtensions.cs
+++ b/src/Backend/Modules/Users/test/SilverbridgeWeb.Modules.Users.ArchitectureTests/Abstractions/TestResultExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using FluentAssertions;
-using NetArchTest.Rules;
 
 namespace SilverbridgeWeb.Modules.Users.ArchitectureTests.Abstractions;
 
 internal static class TestResultExtensions
 {
-    internal static void ShouldBeSuccessful(this TestResult testResult)
+    internal static void ShouldBeSuccessful(this NetArchTest.Rules.TestResult testResult)
     {
         testResult.FailingTypes?.Should().BeEmpty();
     }

--- a/src/Backend/Modules/Users/test/SilverbridgeWeb.Modules.Users.ArchitectureTests/SilverbridgeWeb.Modules.Users.ArchitectureTests.csproj
+++ b/src/Backend/Modules/Users/test/SilverbridgeWeb.Modules.Users.ArchitectureTests/SilverbridgeWeb.Modules.Users.ArchitectureTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -13,7 +14,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NetArchTest.Rules" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/test/SilverbridgeWeb.ArchitectureTests/Abstractions/TestResultExtensions.cs
+++ b/test/SilverbridgeWeb.ArchitectureTests/Abstractions/TestResultExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using FluentAssertions;
-using NetArchTest.Rules;
 
 namespace SilverbridgeWeb.ArchitectureTests.Abstractions;
 
 internal static class TestResultExtensions
 {
-    internal static void ShouldBeSuccessful(this TestResult testResult)
+    internal static void ShouldBeSuccessful(this NetArchTest.Rules.TestResult testResult)
     {
         testResult.FailingTypes?.Should().BeEmpty();
     }

--- a/test/SilverbridgeWeb.ArchitectureTests/SilverbridgeWeb.ArchitectureTests.csproj
+++ b/test/SilverbridgeWeb.ArchitectureTests/SilverbridgeWeb.ArchitectureTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 	<IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -13,7 +14,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NetArchTest.Rules" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because this upgrades the test framework to `xunit.v3` and changes test project output settings, which can impact CI test discovery/execution even though production code is untouched.
> 
> **Overview**
> Bumps several centrally-managed dependencies in `Directory.Packages.props` (notably Aspire packages, `Quartz.Extensions.Hosting`, `SonarAnalyzer.CSharp`, `Microsoft.NET.Test.Sdk`, and `Scalar.AspNetCore`), and replaces `xunit` with `xunit.v3`.
> 
> Migrates all architecture test projects to the new `xunit.v3` package, sets those test projects to `OutputType` `Exe`, and updates `TestResultExtensions.ShouldBeSuccessful` to reference `NetArchTest.Rules.TestResult` via a fully-qualified type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 076a46d153d438d1093b5f11367a3309ee38e690. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->