### PR TITLE
feat: apply club theme and modern fonts

### DIFF
--- a/src/Frontend/SilverbridgeWeb.WebUI/ClubTheme.cs
+++ b/src/Frontend/SilverbridgeWeb.WebUI/ClubTheme.cs
@@ -1,0 +1,46 @@
+using MudBlazor;
+
+namespace SilverbridgeWeb.WebUI;
+
+internal static class ClubTheme
+{
+    private static readonly string[] BodyFonts = ["Inter", "Helvetica", "Arial", "sans-serif"];
+    private static readonly string[] HeadingFonts = ["Montserrat", "sans-serif"];
+
+    public static readonly MudTheme Theme = new()
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#263C9F",
+            Secondary = "#FCCF02",
+            AppbarBackground = "#263C9F",
+            AppbarText = "#FFFFFF",
+            DrawerBackground = "#263C9F",
+            DrawerText = "#FFFFFF",
+            DrawerIcon = "#FCCF02",
+        },
+        PaletteDark = new PaletteDark
+        {
+            Primary = "#4A64C8",
+            Secondary = "#FCCF02",
+            AppbarBackground = "#1A2B70",
+            DrawerBackground = "#1A2B70",
+            DrawerText = "#FFFFFF",
+            DrawerIcon = "#FCCF02",
+        },
+        Typography = new Typography
+        {
+            Default = new DefaultTypography { FontFamily = BodyFonts },
+            H1 = new H1Typography { FontFamily = HeadingFonts, FontWeight = "700" },
+            H2 = new H2Typography { FontFamily = HeadingFonts, FontWeight = "700" },
+            H3 = new H3Typography { FontFamily = HeadingFonts, FontWeight = "700" },
+            H4 = new H4Typography { FontFamily = HeadingFonts, FontWeight = "700" },
+            H5 = new H5Typography { FontFamily = HeadingFonts, FontWeight = "600" },
+            H6 = new H6Typography { FontFamily = HeadingFonts, FontWeight = "600" },
+        },
+        LayoutProperties = new LayoutProperties
+        {
+            DefaultBorderRadius = "8px",
+        },
+    };
+}

--- a/src/Frontend/SilverbridgeWeb.WebUI/Layout/MainLayout.razor
+++ b/src/Frontend/SilverbridgeWeb.WebUI/Layout/MainLayout.razor
@@ -1,7 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
 @* Required *@
-<MudThemeProvider @ref="@_mudThemeProvider" @bind-IsDarkMode="@_isDarkMode" />/>
+<MudThemeProvider @ref="@_mudThemeProvider" @bind-IsDarkMode="@_isDarkMode" Theme="@ClubTheme.Theme" />
 <MudPopoverProvider />
 
 @* Needed for dialogs *@

--- a/src/Frontend/SilverbridgeWeb.WebUI/Layout/MainLayout.razor.css
+++ b/src/Frontend/SilverbridgeWeb.WebUI/Layout/MainLayout.razor.css
@@ -8,70 +8,8 @@ main {
     flex: 1;
 }
 
-.sidebar {
-    background-image: linear-gradient(180deg, rgb(38, 60, 159) 50%, #FCCF02 80%);
-}
-
-.top-row {
-    background-color: #f7f7f7;
-    border-bottom: 1px solid #d6d5d5;
-    justify-content: flex-end;
-    height: 3.5rem;
-    display: flex;
-    align-items: center;
-}
-
-    .top-row ::deep a, .top-row ::deep .btn-link {
-        white-space: nowrap;
-        margin-left: 1.5rem;
-        text-decoration: none;
-    }
-
-    .top-row ::deep a:hover, .top-row ::deep .btn-link:hover {
-        text-decoration: underline;
-    }
-
-    .top-row ::deep a:first-child {
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
-@media (max-width: 640.98px) {
-    .top-row {
-        justify-content: space-between;
-    }
-
-    .top-row ::deep a, .top-row ::deep .btn-link {
-        margin-left: 0;
-    }
-}
-
 @media (min-width: 641px) {
     .page {
         flex-direction: row;
-    }
-
-    .sidebar {
-        width: 250px;
-        height: 100vh;
-        position: sticky;
-        top: 0;
-    }
-
-    .top-row {
-        position: sticky;
-        top: 0;
-        z-index: 1;
-    }
-
-    .top-row.auth ::deep a:first-child {
-        flex: 1;
-        text-align: right;
-        width: 0;
-    }
-
-    .top-row, article {
-        padding-left: 2rem !important;
-        padding-right: 1.5rem !important;
     }
 }

--- a/src/Frontend/SilverbridgeWeb.WebUI/wwwroot/css/app.css
+++ b/src/Frontend/SilverbridgeWeb.WebUI/wwwroot/css/app.css
@@ -1,5 +1,5 @@
 html, body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 h1:focus {
@@ -7,17 +7,17 @@ h1:focus {
 }
 
 a, .btn-link {
-    color: #0071c1;
+    color: var(--mud-palette-primary);
 }
 
 .btn-primary {
     color: #fff;
-    background-color: #1b6ec2;
-    border-color: #1861ac;
+    background-color: #263C9F;
+    border-color: #1e3080;
 }
 
 .btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem var(--mud-palette-primary);
 }
 
 .content {
@@ -84,7 +84,7 @@ a, .btn-link {
     }
 
         .loading-progress circle:last-child {
-            stroke: #1b6ec2;
+            stroke: #263C9F;
             stroke-dasharray: calc(3.141 * var(--blazor-load-percentage, 0%) * 0.8), 500%;
             transition: stroke-dasharray 0.05s ease-in-out;
         }

--- a/src/Frontend/SilverbridgeWeb.WebUI/wwwroot/index.html
+++ b/src/Frontend/SilverbridgeWeb.WebUI/wwwroot/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="SilverbridgeWeb.styles.css" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Montserrat:wght@600;700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
Closes #154

## Summary

Applies a modern look and feel to the app using the club's primary colours.

### Changes
- **ClubTheme.cs** (new) — central MudBlazor theme: Primary \#263C9F\, Secondary \#FCCF02\, blue app bar & drawer with gold icons, dark mode variants, Montserrat headings, Inter body, rounded corners
- **\MainLayout.razor\** — wires \ClubTheme.Theme\ into \MudThemeProvider\ so all components inherit the palette automatically
- **\index.html\** — replaces Roboto with Inter + Montserrat from Google Fonts
- **\pp.css\** — replaces hardcoded blue hex values with \ar(--mud-palette-primary)\ CSS variables
- **\MainLayout.razor.css\** — removes stale Bootstrap-era \.sidebar\ gradient and unused \.top-row\ rules